### PR TITLE
Add Windows UI Automation accessibility support

### DIFF
--- a/Demo/Demo.csproj
+++ b/Demo/Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -15,6 +15,18 @@
 	  <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
 	  <PublishNativeAssetsForSelfExtract>true</PublishNativeAssetsForSelfExtract>
 	  <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64</RuntimeIdentifiers>
+	  <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+  </PropertyGroup>
+
+  <!--
+    Windows UI Automation exposes managed provider interfaces through COM.
+    The built-in COM marshaller required by that provider is not supported by
+    Native AOT or trimming, so keep Windows publishes compatible until the
+    provider is migrated to source-generated ComWrappers.
+  -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64' Or '$(RuntimeIdentifier)' == 'win-x86' Or '$(RuntimeIdentifier)' == 'win-arm64'">
+    <PublishAot>false</PublishAot>
+    <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XcyUI.Controls/Buttons.cs
+++ b/XcyUI.Controls/Buttons.cs
@@ -22,6 +22,8 @@ namespace XcyUI.Controls
                 .FontWeight(Theme.Weights.Button)
                 .Border(Theme.Colors.Primary, 0)
                 .Radius(Theme.Radius.Middle)
+                .AccessibilityRole(XAccessibilityRole.Button)
+                .AccessibilityMergeDescendants()
                 .Click(function);
         }
 
@@ -45,6 +47,9 @@ namespace XcyUI.Controls
         {
             return builder.PrimaryButton()
                 .EnableEvent(false)
+                .Focusable(false)
+                .AccessibilityEnabled(false)
+                .TabIndex(-1)
                 .Shadow(new XShadow())
                .ColorAll(Theme.Colors.DisabledText)
                .Border(new XBorder())
@@ -54,6 +59,9 @@ namespace XcyUI.Controls
         public static XViewBuilder Disable(this XViewBuilder builder)
         {
             return builder.EnableEvent(false)
+               .Focusable(false)
+               .AccessibilityEnabled(false)
+               .TabIndex(-1)
                .Alpha(Theme.Colors.DisabledAlpha);
         }
     }

--- a/XcyUI.Controls/CheckBox.cs
+++ b/XcyUI.Controls/CheckBox.cs
@@ -38,6 +38,11 @@ namespace XcyUI.Controls
             .Space(10)
             .HoverCursor(XCursorType.Hand)
             .Color(xTheme.Colors.White)
+            .AccessibilityRole(XAccessibilityRole.CheckBox)
+            .AccessibilityName(text)
+            .AccessibilityChecked(selectState.Value)
+            .AccessibilityMergeDescendants()
+            .Bind(selectState, (builder, select) => builder.AccessibilityChecked(select))
             .Click(() =>
             {
                 selectState.Value = !selectState.Value;

--- a/XcyUI.Controls/DateTimePicker.cs
+++ b/XcyUI.Controls/DateTimePicker.cs
@@ -16,9 +16,22 @@ namespace XcyUI.Controls
             var dateTimeState = StateValueOf(dateTime, isReset: true);
             return Row(dateTimeState, date =>
             {
-                Input(date.ToString("yyyy-MM-dd")).Weight(1).SingleLine();
+                Input(date.ToString("yyyy-MM-dd"))
+                    .Weight(1)
+                    .SingleLine()
+                    .ReadOnly()
+                    .Focusable(false)
+                    .AccessibilityHidden();
                 Icon(SvgRes.Calendar).IconSize(20);
-            }).PrimaryInput().Space(5).Width(200).Popover(visibleState, ()=>
+            }).PrimaryInput().Space(5).Width(200)
+            .AccessibilityRole(XAccessibilityRole.DatePicker)
+            .AccessibilityName("日期选择器")
+            .AccessibilityValue(dateTimeState.Value.ToString("yyyy-MM-dd"))
+            .AccessibilityExpanded(visibleState.Value)
+            .AccessibilityMergeDescendants()
+            .Bind(dateTimeState, (builder, date) => builder.AccessibilityValue(date.ToString("yyyy-MM-dd")))
+            .Bind(visibleState, (builder, visible) => builder.AccessibilityExpanded(visible))
+            .Popover(visibleState, ()=>
             {
                 DateTimePicker(dateTime, date =>
                 {
@@ -45,6 +58,7 @@ namespace XcyUI.Controls
                 {
                     Icon(SvgRes.DArrowLeft).Size(20)
                     .Margin(vertical: 10).Hand()
+                    .Bind(typeState, (builder, type) => builder.AccessibilityName(type == 1 ? "上十年" : "上一年"))
                     .Click(() =>
                     {
                         if(typeState.Value == 1)
@@ -61,7 +75,9 @@ namespace XcyUI.Controls
                     // 选择天的时候
                     if (typeState.Value == 0)
                     {
-                        Icon(SvgRes.ArrowLeft).Size(20).Hand().Click(() =>
+                        Icon(SvgRes.ArrowLeft).Size(20).Hand()
+                        .AccessibilityName("上个月")
+                        .Click(() =>
                         {
                             currentDateTimeState.Value = currentDateTimeState.Value.AddMonths(-1);
                         }, defaultEffect: false);
@@ -107,13 +123,17 @@ namespace XcyUI.Controls
                     // 选择天的时候
                     if (typeState.Value == 0)
                     {
-                        Icon(SvgRes.ArrowRight).Size(20).Hand().Click(() =>
+                        Icon(SvgRes.ArrowRight).Size(20).Hand()
+                        .AccessibilityName("下个月")
+                        .Click(() =>
                         {
                             currentDateTimeState.Value = currentDateTimeState.Value.AddMonths(1);
                         }, defaultEffect: false);
                     }
 
-                    Icon(SvgRes.DArrowRight).Size(20).Hand().Click(() =>
+                    Icon(SvgRes.DArrowRight).Size(20).Hand()
+                    .Bind(typeState, (builder, type) => builder.AccessibilityName(type == 1 ? "下十年" : "下一年"))
+                    .Click(() =>
                     {
                         if (typeState.Value == 1)
                         {
@@ -258,6 +278,10 @@ namespace XcyUI.Controls
                                 .Also(builder =>
                                 {
                                     var selectDate = selectedDateTimeState.Value;
+                                    builder
+                                    .AccessibilityName(day.ToString("yyyy-MM-dd"))
+                                    .AccessibilitySelected(selectDate == day)
+                                    .AccessibilityEnabled(!isOutDate);
                                     if (selectDate == day)
                                     {
                                         builder

--- a/XcyUI.Controls/Dialog.cs
+++ b/XcyUI.Controls/Dialog.cs
@@ -51,7 +51,9 @@ namespace XcyUI.Controls
                         Icon(SvgRes.WarnTriangleFilled).Size(34).Color(xTheme.Colors.Warning);
                         Text(dialogInfo.Title).H2();
                         Spacer(1).Weight(1);
-                        Icon(SvgRes.Close).Size(48).IconSize(24).Radius(xTheme.Radius.Middle).Click(() =>
+                        Icon(SvgRes.Close).Size(48).IconSize(24).Radius(xTheme.Radius.Middle)
+                        .AccessibilityName("关闭")
+                        .Click(() =>
                         {
                             visisbleState.Value = true;
                         });
@@ -73,6 +75,9 @@ namespace XcyUI.Controls
                     }).Width(FILL).Space(15).HorizontalAlignment(XHorizontalAlignment.Right);
                 }).Size(WRAP).Space(10).MinWidth(400)
                 .HorizontalAlignment(XHorizontalAlignment.Left)
+                .AccessibilityRole(XAccessibilityRole.Dialog)
+                .AccessibilityName(dialogInfo.Title)
+                .AccessibilityDescription(dialogInfo.Content)
                 .Card().Padding(20)
                 .Bind(animateValue, (builder, value) =>
                 {
@@ -105,6 +110,8 @@ namespace XcyUI.Controls
                 {
                     content.Invoke(visisbleState);
                 }).Size(WRAP)
+                .AccessibilityRole(XAccessibilityRole.Dialog)
+                .AccessibilityMergeDescendants()
                 .Card()
                 .Bind(animateValue, (builder, value) =>
                 {

--- a/XcyUI.Controls/Dropdown.cs
+++ b/XcyUI.Controls/Dropdown.cs
@@ -14,6 +14,7 @@ namespace XcyUI.Controls
     {
         public static XViewBuilder MultiDropdown(List<(object, string)> items, XState<List<object>> selectItemsState = null, XFunction<(object, string)> onSelected = null, int popCardWidth = 200)
         {
+            selectItemsState = selectItemsState ?? StateValueOf(new List<object>(), true);
             var selectItems = selectItemsState.Value ?? new List<object>();
             var selectValue = items.Where(n => selectItems.Contains(n.Item1)).Select(n => n.Item2);
             var selectStr = string.Join(",", selectValue);
@@ -44,10 +45,18 @@ namespace XcyUI.Controls
             .PrimaryInput()
             .Width(200)
             .Space(10)
+            .AccessibilityRole(XAccessibilityRole.ComboBox)
+            .AccessibilityName("多选下拉")
+            .AccessibilityValue(selectState.Value)
+            .AccessibilityExpanded(popupVisible.Value)
+            .AccessibilityMergeDescendants()
+            .Bind(selectState, (builder, select) => builder.AccessibilityValue(select))
+            .Bind(popupVisible, (builder, visible) => builder.AccessibilityExpanded(visible))
             .Popover(popupVisible, () =>
             {
                 Column(() =>
                 {
+                    var index = 1;
                     foreach (var item in items)
                     {
                         var isSelected = (selectItemsState.Value ?? new List<object>()).Contains(item.Item1);
@@ -68,9 +77,13 @@ namespace XcyUI.Controls
                             var select = string.Join(",", value);
                             selectState.Value = select;
                             selectItemsState.Value = list;
-                        }).Margin(10);
+                        })
+                        .AccessibilitySetPosition(index, items.Count)
+                        .Margin(10);
+                        index++;
                     }
                 })
+                .AccessibilityRole(XAccessibilityRole.ListBox)
                 .Scrollable()
                 .HorizontalAlignment(XHorizontalAlignment.Left)
                 .Margin(5).Size(WRAP).MinWidth(150).MaxHeight(500).Width(popCardWidth);
@@ -85,6 +98,7 @@ namespace XcyUI.Controls
 
         public static XViewBuilder Dropdown(List<(object, string)> items, XState<object> selectItemState = null, XFunction<(object, string)> onSelected = null, int popCardWidth = 200)
         {
+            selectItemState = selectItemState ?? StateValueOf<object>(null, true);
             var selectValue = items.FirstOrDefault(n => n.Item1.Equals(selectItemState?.Value)).Item2;
             var selectState = StateValueOf(selectValue?.ToString()??"", true);
             var popupVisible = StateValueOf(false);
@@ -112,10 +126,18 @@ namespace XcyUI.Controls
             .PrimaryInput()
             .Width(200)
             .Space(10)
+            .AccessibilityRole(XAccessibilityRole.ComboBox)
+            .AccessibilityName("下拉选择")
+            .AccessibilityValue(selectState.Value)
+            .AccessibilityExpanded(popupVisible.Value)
+            .AccessibilityMergeDescendants()
+            .Bind(selectState, (builder, select) => builder.AccessibilityValue(select))
+            .Bind(popupVisible, (builder, visible) => builder.AccessibilityExpanded(visible))
             .Popover(popupVisible, () =>
             {
                 Column(() =>
                 {
+                    var index = 1;
                     foreach (var item in items)
                     {
                         Row(() =>
@@ -126,6 +148,10 @@ namespace XcyUI.Controls
                             Text(item.Item2);
                         })
                         .Width(FILL).Space(10).Padding(10)
+                        .AccessibilityRole(XAccessibilityRole.ListItem)
+                        .AccessibilityName(item.Item2)
+                        .AccessibilitySelected(item.Item1.Equals(selectItemState?.Value))
+                        .AccessibilitySetPosition(index, items.Count)
                         .Click(()=>
                         {
                             var selectItem = (item.Item1, item.Item2);
@@ -134,8 +160,10 @@ namespace XcyUI.Controls
                             selectItemState.Value = item.Item1;
                             popupVisible.Value = false;
                         });
+                        index++;
                     }
                 })
+                .AccessibilityRole(XAccessibilityRole.ListBox)
                 .Scrollable()
                 .HorizontalAlignment(XHorizontalAlignment.Left)
                 .Margin(5).Size(WRAP).MinWidth(150).MaxHeight(500).Width(popCardWidth);

--- a/XcyUI.Controls/Labels.cs
+++ b/XcyUI.Controls/Labels.cs
@@ -20,20 +20,23 @@ namespace XcyUI.Controls
 
         public static XViewBuilder H1(this XViewBuilder builder)
         {
-            builder.Color(Theme.Colors.RegularText).FontSize(Theme.Sizes.H1).FontWeight(Theme.Weights.Large);
+            builder.Color(Theme.Colors.RegularText).FontSize(Theme.Sizes.H1).FontWeight(Theme.Weights.Large)
+                .AccessibilityHeadingLevel(1);
             return builder;
         }
 
         public static XViewBuilder H2(this XViewBuilder builder)
         {
-            builder.Color(Theme.Colors.RegularText).FontSize(Theme.Sizes.H2).FontWeight(Theme.Weights.Large);
+            builder.Color(Theme.Colors.RegularText).FontSize(Theme.Sizes.H2).FontWeight(Theme.Weights.Large)
+                .AccessibilityHeadingLevel(2);
             return builder;
         }
 
         public static XViewBuilder H3(this XViewBuilder builder)
         {
             builder.Color(Theme.Colors.RegularText)
-                .FontSize(Theme.Sizes.H3).FontWeight(Theme.Weights.Large);
+                .FontSize(Theme.Sizes.H3).FontWeight(Theme.Weights.Large)
+                .AccessibilityHeadingLevel(3);
             return builder;
         }
 

--- a/XcyUI.Controls/PopoverBox.cs
+++ b/XcyUI.Controls/PopoverBox.cs
@@ -31,6 +31,8 @@ namespace XcyUI.Controls
             {
                 visibleState.Value = false;
             })
+            .AccessibilityExpanded(visibleState.Value)
+            .Bind(visibleState, (b, visible) => b.AccessibilityExpanded(visible))
             .BubbleEvent(XEventType.Click)
             .Click(() =>
             {

--- a/XcyUI.Controls/Progress.cs
+++ b/XcyUI.Controls/Progress.cs
@@ -30,6 +30,8 @@ namespace XcyUI.Controls
         {
             var borderBursh = new XBrush() { StartColor = color, EndColor = color.Copy(0f), Direction = XGradientDirection.Round };
             return Spacer(size).Circle()
+               .AccessibilityRole(XAccessibilityRole.ProgressBar)
+               .AccessibilityValue("loading")
                .EnableCache(true)
                .EnableOverDraw(true)
                .Border(new XBorder() { Color = borderBursh, Size = new XSpace(borderSize.AsPx()) })
@@ -46,9 +48,12 @@ namespace XcyUI.Controls
         {
             return Spacer(size)
                 .Circle()
+                .AccessibilityRole(XAccessibilityRole.ProgressBar)
+                .AccessibilityValue(progress.Value.ToString("P0"))
                 .Border(xTheme.Colors.BaseBorder, borderSize)
                 .Bind(progress, (builder, value) =>
                 {
+                    builder.AccessibilityValue(value.ToString("P0"));
                     builder.View.Invalidate();
                 })
                 .OnDraw(builder =>

--- a/XcyUI.Controls/RadioBox.cs
+++ b/XcyUI.Controls/RadioBox.cs
@@ -46,7 +46,12 @@ namespace XcyUI.Controls
                     }
                 }).Size(WRAP);
                 Text(text);
-            }).Space(10).HoverCursor(XCursorType.Hand);
+            }).Space(10)
+            .HoverCursor(XCursorType.Hand)
+            .AccessibilityRole(XAccessibilityRole.RadioButton)
+            .AccessibilityName(text)
+            .AccessibilityChecked(select)
+            .AccessibilityMergeDescendants();
         }
     }
 }

--- a/XcyUI.Controls/SwitchButtons.cs
+++ b/XcyUI.Controls/SwitchButtons.cs
@@ -35,10 +35,14 @@ namespace XcyUI.Controls
                 });
             })
             .Size(66, 33).Padding(horizontal: 2).Radius(16)
+            .AccessibilityRole(XAccessibilityRole.Switch)
+            .AccessibilityName("开关")
+            .AccessibilityChecked(selectedState.Value)
             .Bind(selectedState, (builder, isSelect) =>
             {
                 var backgroundColor = isSelect ? xTheme.Colors.Primary : xTheme.Colors.BaseBorder;
-                builder.Background(backgroundColor);
+                builder.Background(backgroundColor)
+                    .AccessibilityChecked(isSelect);
             })
             .Click(() =>
             {

--- a/XcyUI.Controls/Tooltip.cs
+++ b/XcyUI.Controls/Tooltip.cs
@@ -14,6 +14,7 @@ namespace XcyUI.Controls
         public static XViewBuilder Tooltip(this XViewBuilder builder, string tips)
         {
             var tipsState = StateValueOf(tips, true);
+            builder.AccessibilityDescription(tips);
             builder.ToggleHover(isHover =>
             {
                 if (string.IsNullOrEmpty(tipsState.Value)) return;
@@ -30,6 +31,7 @@ namespace XcyUI.Controls
             {
                 Text(textState.Value)
                 .Alignment(XAlignment.LeftTop)
+                .AccessibilityRole(XAccessibilityRole.Tooltip)
                 .MiniCard()
                 .Background(xTheme.Colors.Black)
                 .Color(xTheme.Colors.White)

--- a/XcyUI.GLFW/accessibility/WindowsUiaBridge.cs
+++ b/XcyUI.GLFW/accessibility/WindowsUiaBridge.cs
@@ -1,0 +1,425 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using XcyUI.events;
+using XcyUI.models;
+using XcyUI.utils;
+using XcyUI.views;
+using static XcyUI.models.XFunctions;
+
+namespace XcyUI.GLFW.accessibility
+{
+    internal sealed class WindowsUiaBridge : IDisposable
+    {
+        private const int GWLP_WNDPROC = -4;
+        private const uint WM_GETOBJECT = 0x003D;
+
+        private readonly IntPtr hwnd;
+        private readonly Func<XAccessibilityNode> getAccessibilityTree;
+        private readonly WindowsUiaRootElementProvider rootProvider;
+        private readonly WndProc wndProc;
+        private readonly Action<XFunction> dispatchToUiThread;
+        private IntPtr previousWndProc;
+        private IRawElementProviderSimple hostProvider;
+        private bool disposed;
+
+        internal delegate IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW")]
+        private static extern IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW")]
+        private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        [DllImport("user32.dll", EntryPoint = "CallWindowProcW")]
+        private static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        private static extern bool ClientToScreen(IntPtr hWnd, ref POINT lpPoint);
+
+        [DllImport("UIAutomationCore.dll")]
+        private static extern IntPtr UiaReturnRawElementProvider(
+            IntPtr hwnd,
+            IntPtr wParam,
+            IntPtr lParam,
+            [MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider);
+
+        [DllImport("UIAutomationCore.dll")]
+        private static extern int UiaHostProviderFromHwnd(IntPtr hwnd, out IntPtr provider);
+
+        [DllImport("UIAutomationCore.dll")]
+        private static extern int UiaRaiseAutomationEvent(
+            [MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider,
+            int eventId);
+
+        [DllImport("UIAutomationCore.dll")]
+        private static extern int UiaRaiseStructureChangedEvent(
+            [MarshalAs(UnmanagedType.Interface)] IRawElementProviderSimple provider,
+            UiaStructureChangeType structureChangeType,
+            IntPtr runtimeId,
+            int runtimeIdLength);
+
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct POINT
+        {
+            public int X;
+            public int Y;
+        }
+
+        public WindowsUiaBridge(IntPtr hwnd, Func<XAccessibilityNode> getAccessibilityTree, Action<XFunction> dispatchToUiThread)
+        {
+            this.hwnd = hwnd;
+            this.getAccessibilityTree = getAccessibilityTree;
+            this.dispatchToUiThread = dispatchToUiThread;
+            rootProvider = new WindowsUiaRootElementProvider(this);
+            wndProc = WindowProc;
+            previousWndProc = GetWindowLongPtr(hwnd, GWLP_WNDPROC);
+            SetWindowLongPtr(hwnd, GWLP_WNDPROC, Marshal.GetFunctionPointerForDelegate(wndProc));
+            XEvent.AccessibilityFocusChanged += OnAccessibilityFocusChanged;
+            XAccessibility.StructureChanged += OnAccessibilityStructureChanged;
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            try
+            {
+                // Release UIA's provider-event references before the HWND is destroyed.
+                UiaReturnRawElementProvider(hwnd, IntPtr.Zero, IntPtr.Zero, null);
+            }
+            catch
+            {
+                // Cleanup must not prevent normal window teardown.
+            }
+
+            var current = GetWindowLongPtr(hwnd, GWLP_WNDPROC);
+            var mine = Marshal.GetFunctionPointerForDelegate(wndProc);
+            if (current == mine && previousWndProc != IntPtr.Zero)
+            {
+                SetWindowLongPtr(hwnd, GWLP_WNDPROC, previousWndProc);
+            }
+
+            XEvent.AccessibilityFocusChanged -= OnAccessibilityFocusChanged;
+            XAccessibility.StructureChanged -= OnAccessibilityStructureChanged;
+            disposed = true;
+        }
+
+        private IntPtr WindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+        {
+            if (msg == WM_GETOBJECT && lParam.ToInt64() == UiaIds.UiaRootObjectId)
+            {
+                return UiaReturnRawElementProvider(hWnd, wParam, lParam, rootProvider);
+            }
+
+            return CallWindowProc(previousWndProc, hWnd, msg, wParam, lParam);
+        }
+
+        internal WindowsUiaSnapshotNode RootSnapshot
+        {
+            get
+            {
+                var tree = getAccessibilityTree?.Invoke();
+                return tree == null ? null : WindowsUiaSnapshotNode.Create(tree, null);
+            }
+        }
+
+        internal IntPtr Hwnd => hwnd;
+        internal WindowsUiaRootElementProvider RootProvider => rootProvider;
+
+        private void OnAccessibilityFocusChanged(XView view)
+        {
+            if (disposed || view == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var node = RootSnapshot?.Flatten().FirstOrDefault(n => ReferenceEquals(n.Node.View, view));
+                var provider = CreateProvider(node);
+                if (provider != null)
+                {
+                    UiaRaiseAutomationEvent(provider, UiaIds.AutomationFocusChangedEventId);
+                }
+            }
+            catch
+            {
+                // Accessibility notifications must not interrupt the UI event loop.
+            }
+        }
+
+        private void OnAccessibilityStructureChanged(XView container)
+        {
+            if (disposed || container == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var node = RootSnapshot?.Flatten().FirstOrDefault(n => ReferenceEquals(n.Node.View, container));
+                var provider = CreateProvider(node);
+                if (provider != null)
+                {
+                    UiaRaiseStructureChangedEvent(provider, UiaStructureChangeType.ChildrenInvalidated, IntPtr.Zero, 0);
+                }
+            }
+            catch
+            {
+                // Accessibility notifications must not interrupt the UI event loop.
+            }
+        }
+
+        internal IRawElementProviderSimple HostProvider
+        {
+            get
+            {
+                if (hostProvider != null)
+                {
+                    return hostProvider;
+                }
+
+                IntPtr provider;
+                var hr = UiaHostProviderFromHwnd(hwnd, out provider);
+                if (hr < 0 || provider == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                try
+                {
+                    hostProvider = Marshal.GetObjectForIUnknown(provider) as IRawElementProviderSimple;
+                    return hostProvider;
+                }
+                finally
+                {
+                    Marshal.Release(provider);
+                }
+            }
+        }
+
+        internal WindowsUiaSnapshotNode Resolve(int? runtimeId)
+        {
+            var root = RootSnapshot;
+            if (root == null)
+            {
+                return null;
+            }
+
+            if (!runtimeId.HasValue)
+            {
+                return root;
+            }
+
+            return root.Flatten().FirstOrDefault(n => n.RuntimeId == runtimeId.Value);
+        }
+
+        internal WindowsUiaElementProvider CreateProvider(WindowsUiaSnapshotNode node)
+        {
+            if (node == null)
+            {
+                return null;
+            }
+
+            return node.Parent == null ? rootProvider : new WindowsUiaElementProvider(this, node.RuntimeId);
+        }
+
+        internal UiaRect ToScreenRect(XRect rect)
+        {
+            var point = new POINT() { X = rect.X, Y = rect.Y };
+            ClientToScreen(hwnd, ref point);
+            return new UiaRect(point.X, point.Y, rect.Width, rect.Height);
+        }
+
+        internal WindowsUiaSnapshotNode ElementFromPoint(double screenX, double screenY)
+        {
+            var root = RootSnapshot;
+            if (root == null)
+            {
+                return null;
+            }
+
+            WindowsUiaSnapshotNode result = null;
+            foreach (var node in root.Flatten())
+            {
+                var rect = ToScreenRect(node.Node.Bounds);
+                if (screenX >= rect.Left
+                    && screenX <= rect.Left + rect.Width
+                    && screenY >= rect.Top
+                    && screenY <= rect.Top + rect.Height)
+                {
+                    result = node;
+                }
+            }
+            return result ?? root;
+        }
+
+        internal WindowsUiaSnapshotNode FocusedElement()
+        {
+            var root = RootSnapshot;
+            return root?.Flatten().FirstOrDefault(n => n.Node.Focused);
+        }
+
+        internal void SetFocus(WindowsUiaSnapshotNode node)
+        {
+            if (node?.Node.View == null)
+            {
+                return;
+            }
+
+            DispatchToUiThread(() => XEvent.SetFocus(node.Node.View));
+        }
+
+        internal void Invoke(WindowsUiaSnapshotNode node)
+        {
+            if (node?.Node.View == null)
+            {
+                return;
+            }
+
+            DispatchToUiThread(() => XEvent.Activate(node.Node.View));
+        }
+
+        internal void SetValue(WindowsUiaSnapshotNode node, string value)
+        {
+            var input = node?.Node.View as XInput;
+            if (input == null || node.Node.ReadOnly == true)
+            {
+                return;
+            }
+
+            DispatchToUiThread(() =>
+            {
+                input.Text = value ?? "";
+                input.StartLayout();
+                input.Invalidate();
+            });
+        }
+
+        private void DispatchToUiThread(XFunction action)
+        {
+            if (disposed || action == null)
+            {
+                return;
+            }
+
+            if (dispatchToUiThread != null)
+            {
+                dispatchToUiThread(action);
+            }
+            else
+            {
+                action.Invoke();
+            }
+        }
+
+        internal static int GetControlType(XAccessibilityRole role)
+        {
+            switch (role)
+            {
+                case XAccessibilityRole.Button:
+                    return UiaIds.ButtonControlTypeId;
+                case XAccessibilityRole.Link:
+                    return UiaIds.HyperlinkControlTypeId;
+                case XAccessibilityRole.Image:
+                    return UiaIds.ImageControlTypeId;
+                case XAccessibilityRole.TextBox:
+                case XAccessibilityRole.TextArea:
+                    return UiaIds.EditControlTypeId;
+                case XAccessibilityRole.CheckBox:
+                    return UiaIds.CheckBoxControlTypeId;
+                case XAccessibilityRole.RadioButton:
+                    return UiaIds.RadioButtonControlTypeId;
+                case XAccessibilityRole.Switch:
+                    return UiaIds.ButtonControlTypeId;
+                case XAccessibilityRole.ComboBox:
+                case XAccessibilityRole.DatePicker:
+                    return UiaIds.ComboBoxControlTypeId;
+                case XAccessibilityRole.ListBox:
+                    return UiaIds.ListControlTypeId;
+                case XAccessibilityRole.ListItem:
+                    return UiaIds.ListItemControlTypeId;
+                case XAccessibilityRole.Menu:
+                    return UiaIds.MenuControlTypeId;
+                case XAccessibilityRole.MenuItem:
+                    return UiaIds.MenuItemControlTypeId;
+                case XAccessibilityRole.Dialog:
+                case XAccessibilityRole.Window:
+                    return UiaIds.WindowControlTypeId;
+                case XAccessibilityRole.Tooltip:
+                    return UiaIds.ToolTipControlTypeId;
+                case XAccessibilityRole.ProgressBar:
+                    return UiaIds.ProgressBarControlTypeId;
+                case XAccessibilityRole.Slider:
+                    return UiaIds.SliderControlTypeId;
+                case XAccessibilityRole.ScrollBar:
+                    return UiaIds.ScrollBarControlTypeId;
+                case XAccessibilityRole.Separator:
+                    return UiaIds.SeparatorControlTypeId;
+                case XAccessibilityRole.Tab:
+                    return UiaIds.TabItemControlTypeId;
+                case XAccessibilityRole.TabPanel:
+                    return UiaIds.TabControlTypeId;
+                case XAccessibilityRole.Status:
+                    return UiaIds.StatusBarControlTypeId;
+                case XAccessibilityRole.Group:
+                case XAccessibilityRole.Application:
+                    return UiaIds.GroupControlTypeId;
+                case XAccessibilityRole.Text:
+                case XAccessibilityRole.Heading:
+                default:
+                    return UiaIds.TextControlTypeId;
+            }
+        }
+
+        internal static string GetLocalizedControlType(XAccessibilityRole role)
+        {
+            return role.ToString();
+        }
+    }
+
+    internal sealed class WindowsUiaSnapshotNode
+    {
+        public XAccessibilityNode Node { get; private set; }
+        public WindowsUiaSnapshotNode Parent { get; private set; }
+        public List<WindowsUiaSnapshotNode> Children { get; private set; }
+        public int RuntimeId { get; private set; }
+
+        private WindowsUiaSnapshotNode(XAccessibilityNode node, WindowsUiaSnapshotNode parent)
+        {
+            Node = node;
+            Parent = parent;
+            Children = new List<WindowsUiaSnapshotNode>();
+            RuntimeId = node.View == null ? 1 : node.View.GetHashCode();
+        }
+
+        public static WindowsUiaSnapshotNode Create(XAccessibilityNode node, WindowsUiaSnapshotNode parent)
+        {
+            var snapshot = new WindowsUiaSnapshotNode(node, parent);
+            foreach (var child in node.Children)
+            {
+                snapshot.Children.Add(Create(child, snapshot));
+            }
+            return snapshot;
+        }
+
+        public IEnumerable<WindowsUiaSnapshotNode> Flatten()
+        {
+            yield return this;
+            foreach (var child in Children)
+            {
+                foreach (var item in child.Flatten())
+                {
+                    yield return item;
+                }
+            }
+        }
+    }
+}

--- a/XcyUI.GLFW/accessibility/WindowsUiaElementProvider.cs
+++ b/XcyUI.GLFW/accessibility/WindowsUiaElementProvider.cs
@@ -1,0 +1,388 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using XcyUI.models;
+
+namespace XcyUI.GLFW.accessibility
+{
+    [ComVisible(true)]
+    [ClassInterface(ClassInterfaceType.None)]
+    internal class WindowsUiaElementProvider :
+        IRawElementProviderSimple,
+        IRawElementProviderFragment,
+        IInvokeProvider,
+        IValueProvider,
+        IToggleProvider,
+        IExpandCollapseProvider,
+        ISelectionItemProvider
+    {
+        private readonly WindowsUiaBridge bridge;
+        private readonly int? runtimeId;
+
+        protected WindowsUiaBridge Bridge => bridge;
+
+        public WindowsUiaElementProvider(WindowsUiaBridge bridge, int? runtimeId)
+        {
+            this.bridge = bridge;
+            this.runtimeId = runtimeId;
+        }
+
+        public UiaProviderOptions ProviderOptions => UiaProviderOptions.ServerSideProvider;
+
+        public IRawElementProviderSimple HostRawElementProvider
+        {
+            get
+            {
+                return runtimeId.HasValue ? null : bridge.HostProvider;
+            }
+        }
+
+        public UiaRect BoundingRectangle
+        {
+            get
+            {
+                var node = CurrentNode;
+                return node == null ? new UiaRect() : bridge.ToScreenRect(node.Node.Bounds);
+            }
+        }
+
+        public IRawElementProviderFragmentRoot FragmentRoot => bridge.RootProvider;
+
+        public string Value
+        {
+            get
+            {
+                var node = CurrentNode;
+                return node?.Node.Value ?? "";
+            }
+        }
+
+        public bool IsReadOnly
+        {
+            get
+            {
+                var node = CurrentNode;
+                return node?.Node.ReadOnly == true;
+            }
+        }
+
+        public UiaToggleState ToggleState
+        {
+            get
+            {
+                var node = CurrentNode;
+                if (node?.Node.Checked == true)
+                {
+                    return UiaToggleState.On;
+                }
+                return UiaToggleState.Off;
+            }
+        }
+
+        public UiaExpandCollapseState ExpandCollapseState
+        {
+            get
+            {
+                var node = CurrentNode;
+                if (node == null || !node.Node.Expanded.HasValue)
+                {
+                    return UiaExpandCollapseState.LeafNode;
+                }
+                return node.Node.Expanded == true ? UiaExpandCollapseState.Expanded : UiaExpandCollapseState.Collapsed;
+            }
+        }
+
+        public bool IsSelected
+        {
+            get
+            {
+                var node = CurrentNode;
+                return node?.Node.Selected == true || node?.Node.Checked == true;
+            }
+        }
+
+        public IRawElementProviderSimple SelectionContainer
+        {
+            get
+            {
+                var parent = CurrentNode?.Parent;
+                while (parent != null)
+                {
+                    if (parent.Node.Role == XAccessibilityRole.ListBox
+                        || parent.Node.Role == XAccessibilityRole.ComboBox
+                        || parent.Node.Role == XAccessibilityRole.Group)
+                    {
+                        return bridge.CreateProvider(parent);
+                    }
+                    parent = parent.Parent;
+                }
+                return null;
+            }
+        }
+
+        private WindowsUiaSnapshotNode CurrentNode => bridge.Resolve(runtimeId);
+
+        public object GetPatternProvider(int patternId)
+        {
+            var node = CurrentNode;
+            if (node == null)
+            {
+                return null;
+            }
+
+            switch (patternId)
+            {
+                case UiaIds.InvokePatternId:
+                    return IsInvokable(node) ? (IInvokeProvider)this : null;
+                case UiaIds.ValuePatternId:
+                    return IsValueProvider(node) ? (IValueProvider)this : null;
+                case UiaIds.TogglePatternId:
+                    return IsToggleProvider(node) ? (IToggleProvider)this : null;
+                case UiaIds.ExpandCollapsePatternId:
+                    return node.Node.Expanded.HasValue ? (IExpandCollapseProvider)this : null;
+                case UiaIds.SelectionItemPatternId:
+                    return IsSelectionItemProvider(node) ? (ISelectionItemProvider)this : null;
+                default:
+                    return null;
+            }
+        }
+
+        public object GetPropertyValue(int propertyId)
+        {
+            var node = CurrentNode;
+            if (node == null)
+            {
+                return null;
+            }
+
+            switch (propertyId)
+            {
+                case UiaIds.RuntimeIdPropertyId:
+                    return GetRuntimeId();
+                case UiaIds.BoundingRectanglePropertyId:
+                    return BoundingRectangle;
+                case UiaIds.ProcessIdPropertyId:
+                    return Process.GetCurrentProcess().Id;
+                case UiaIds.ControlTypePropertyId:
+                    return WindowsUiaBridge.GetControlType(node.Node.Role);
+                case UiaIds.LocalizedControlTypePropertyId:
+                    return WindowsUiaBridge.GetLocalizedControlType(node.Node.Role);
+                case UiaIds.NamePropertyId:
+                    return node.Node.Name ?? "";
+                case UiaIds.HasKeyboardFocusPropertyId:
+                    return node.Node.Focused;
+                case UiaIds.IsKeyboardFocusablePropertyId:
+                    return node.Node.Focusable;
+                case UiaIds.IsEnabledPropertyId:
+                    return node.Node.Enabled;
+                case UiaIds.AutomationIdPropertyId:
+                    return "xcyui-" + node.RuntimeId;
+                case UiaIds.ClassNamePropertyId:
+                    return "XcyUI." + node.Node.Role;
+                case UiaIds.HelpTextPropertyId:
+                    return node.Node.Description ?? node.Node.Hint ?? "";
+                case UiaIds.IsControlElementPropertyId:
+                    return true;
+                case UiaIds.IsContentElementPropertyId:
+                    return !runtimeId.HasValue || node.Node.Role != XAccessibilityRole.Group;
+                case UiaIds.IsPasswordPropertyId:
+                    return node.Node.Password == true;
+                case UiaIds.NativeWindowHandlePropertyId:
+                    return runtimeId.HasValue ? 0 : unchecked((int)bridge.Hwnd.ToInt64());
+                case UiaIds.IsOffscreenPropertyId:
+                    return node.Node.Bounds.Width <= 0 || node.Node.Bounds.Height <= 0;
+                case UiaIds.FrameworkIdPropertyId:
+                    return "XcyUI";
+                case UiaIds.IsRequiredForFormPropertyId:
+                    return node.Node.Required == true;
+                case UiaIds.ValueValuePropertyId:
+                    return Value;
+                case UiaIds.ValueIsReadOnlyPropertyId:
+                    return IsReadOnly;
+                case UiaIds.ExpandCollapseExpandCollapseStatePropertyId:
+                    return ExpandCollapseState;
+                case UiaIds.SelectionItemIsSelectedPropertyId:
+                    return IsSelected;
+                case UiaIds.ToggleToggleStatePropertyId:
+                    return ToggleState;
+                default:
+                    return null;
+            }
+        }
+
+        public IRawElementProviderFragment Navigate(UiaNavigateDirection direction)
+        {
+            var node = CurrentNode;
+            if (node == null)
+            {
+                return null;
+            }
+
+            switch (direction)
+            {
+                case UiaNavigateDirection.Parent:
+                    return node.Parent == null ? null : bridge.CreateProvider(node.Parent);
+                case UiaNavigateDirection.FirstChild:
+                    return node.Children.Count == 0 ? null : bridge.CreateProvider(node.Children[0]);
+                case UiaNavigateDirection.LastChild:
+                    return node.Children.Count == 0 ? null : bridge.CreateProvider(node.Children[node.Children.Count - 1]);
+                case UiaNavigateDirection.NextSibling:
+                    return GetSibling(node, 1);
+                case UiaNavigateDirection.PreviousSibling:
+                    return GetSibling(node, -1);
+                default:
+                    return null;
+            }
+        }
+
+        public int[] GetRuntimeId()
+        {
+            var node = CurrentNode;
+            if (node == null)
+            {
+                return null;
+            }
+
+            if (!runtimeId.HasValue)
+            {
+                return null;
+            }
+
+            return new[] { UiaIds.UiaAppendRuntimeId, node.RuntimeId };
+        }
+
+        public IRawElementProviderSimple[] GetEmbeddedFragmentRoots()
+        {
+            return null;
+        }
+
+        public void SetFocus()
+        {
+            bridge.SetFocus(CurrentNode);
+        }
+
+        public void Invoke()
+        {
+            bridge.Invoke(CurrentNode);
+        }
+
+        public void SetValue(string value)
+        {
+            bridge.SetValue(CurrentNode, value);
+        }
+
+        public void Toggle()
+        {
+            bridge.Invoke(CurrentNode);
+        }
+
+        public void Expand()
+        {
+            var node = CurrentNode;
+            if (node?.Node.Expanded == false)
+            {
+                bridge.Invoke(node);
+            }
+        }
+
+        public void Collapse()
+        {
+            var node = CurrentNode;
+            if (node?.Node.Expanded == true)
+            {
+                bridge.Invoke(node);
+            }
+        }
+
+        public void Select()
+        {
+            var node = CurrentNode;
+            if (node?.Node.Selected != true && node?.Node.Checked != true)
+            {
+                bridge.Invoke(node);
+            }
+        }
+
+        public void AddToSelection()
+        {
+            Select();
+        }
+
+        public void RemoveFromSelection()
+        {
+            var node = CurrentNode;
+            if (node?.Node.Selected == true || node?.Node.Checked == true)
+            {
+                bridge.Invoke(node);
+            }
+        }
+
+        private IRawElementProviderFragment GetSibling(WindowsUiaSnapshotNode node, int offset)
+        {
+            if (node.Parent == null)
+            {
+                return null;
+            }
+
+            var index = node.Parent.Children.IndexOf(node);
+            var siblingIndex = index + offset;
+            if (siblingIndex < 0 || siblingIndex >= node.Parent.Children.Count)
+            {
+                return null;
+            }
+
+            return bridge.CreateProvider(node.Parent.Children[siblingIndex]);
+        }
+
+        private static bool IsInvokable(WindowsUiaSnapshotNode node)
+        {
+            var role = node.Node.Role;
+            return role == XAccessibilityRole.Button
+                || role == XAccessibilityRole.Link
+                || role == XAccessibilityRole.ComboBox
+                || role == XAccessibilityRole.DatePicker
+                || role == XAccessibilityRole.ListItem
+                || role == XAccessibilityRole.MenuItem
+                || role == XAccessibilityRole.Tab;
+        }
+
+        private static bool IsValueProvider(WindowsUiaSnapshotNode node)
+        {
+            return node.Node.Role == XAccessibilityRole.TextBox
+                || node.Node.Role == XAccessibilityRole.TextArea;
+        }
+
+        private static bool IsToggleProvider(WindowsUiaSnapshotNode node)
+        {
+            return node.Node.Role == XAccessibilityRole.CheckBox
+                || node.Node.Role == XAccessibilityRole.Switch;
+        }
+
+        private static bool IsSelectionItemProvider(WindowsUiaSnapshotNode node)
+        {
+            return node.Node.Role == XAccessibilityRole.RadioButton
+                || node.Node.Role == XAccessibilityRole.ListItem
+                || node.Node.Role == XAccessibilityRole.Tab;
+        }
+    }
+
+    [ComVisible(true)]
+    [ClassInterface(ClassInterfaceType.None)]
+    internal sealed class WindowsUiaRootElementProvider : WindowsUiaElementProvider, IRawElementProviderFragmentRoot
+    {
+        public WindowsUiaRootElementProvider(WindowsUiaBridge bridge)
+            : base(bridge, null)
+        {
+        }
+
+        public IRawElementProviderFragment ElementProviderFromPoint(double x, double y)
+        {
+            return Bridge.CreateProvider(Bridge.ElementFromPoint(x, y));
+        }
+
+        public IRawElementProviderFragment GetFocus()
+        {
+            return Bridge.CreateProvider(Bridge.FocusedElement());
+        }
+    }
+}

--- a/XcyUI.GLFW/accessibility/WindowsUiaNative.cs
+++ b/XcyUI.GLFW/accessibility/WindowsUiaNative.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace XcyUI.GLFW.accessibility
+{
+    [Flags]
+    public enum UiaProviderOptions
+    {
+        ClientSideProvider = 1,
+        ServerSideProvider = 2,
+        NonClientAreaProvider = 4,
+        OverrideProvider = 8,
+        ProviderOwnsSetFocus = 16,
+        UseComThreading = 32
+    }
+
+    public enum UiaNavigateDirection
+    {
+        Parent = 0,
+        NextSibling = 1,
+        PreviousSibling = 2,
+        FirstChild = 3,
+        LastChild = 4
+    }
+
+    public enum UiaToggleState
+    {
+        Off = 0,
+        On = 1,
+        Indeterminate = 2
+    }
+
+    public enum UiaExpandCollapseState
+    {
+        Collapsed = 0,
+        Expanded = 1,
+        PartiallyExpanded = 2,
+        LeafNode = 3
+    }
+
+    public enum UiaStructureChangeType
+    {
+        ChildAdded = 0,
+        ChildRemoved = 1,
+        ChildrenInvalidated = 2,
+        ChildrenBulkAdded = 3,
+        ChildrenBulkRemoved = 4,
+        ChildrenReordered = 5
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct UiaRect
+    {
+        public double Left;
+        public double Top;
+        public double Width;
+        public double Height;
+
+        public UiaRect(double left, double top, double width, double height)
+        {
+            Left = left;
+            Top = top;
+            Width = width;
+            Height = height;
+        }
+    }
+
+    [ComVisible(true)]
+    [Guid("D6DD68D1-86FD-4332-8666-9ABEDEA2D24C")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IRawElementProviderSimple
+    {
+        UiaProviderOptions ProviderOptions { get; }
+        [return: MarshalAs(UnmanagedType.IUnknown)]
+        object GetPatternProvider(int patternId);
+
+        object GetPropertyValue(int propertyId);
+        IRawElementProviderSimple HostRawElementProvider { get; }
+    }
+
+    [ComVisible(true)]
+    [Guid("F7063DA8-8359-439C-9297-BBC5299A7D87")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IRawElementProviderFragment : IRawElementProviderSimple
+    {
+        IRawElementProviderFragment Navigate(UiaNavigateDirection direction);
+
+        int[] GetRuntimeId();
+
+        UiaRect BoundingRectangle { get; }
+
+        IRawElementProviderSimple[] GetEmbeddedFragmentRoots();
+
+        void SetFocus();
+        IRawElementProviderFragmentRoot FragmentRoot { get; }
+    }
+
+    [ComVisible(true)]
+    [Guid("620CE2A5-AB8F-40A9-86CB-DE3C75599B58")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IRawElementProviderFragmentRoot : IRawElementProviderFragment
+    {
+        IRawElementProviderFragment ElementProviderFromPoint(double x, double y);
+        IRawElementProviderFragment GetFocus();
+    }
+
+    [ComVisible(true)]
+    [Guid("54FCB24B-E18E-47A2-B4D3-ECCBE77599A2")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IInvokeProvider
+    {
+        void Invoke();
+    }
+
+    [ComVisible(true)]
+    [Guid("C7935180-6FB3-4201-B174-7DF73ADBF64A")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IValueProvider
+    {
+        void SetValue(string value);
+        string Value { get; }
+        bool IsReadOnly { get; }
+    }
+
+    [ComVisible(true)]
+    [Guid("56D00BD0-C4F4-433C-A836-1A52A57E0892")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IToggleProvider
+    {
+        void Toggle();
+        UiaToggleState ToggleState { get; }
+    }
+
+    [ComVisible(true)]
+    [Guid("D847D3A5-CAB0-4A98-8C32-ECB45C59AD24")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IExpandCollapseProvider
+    {
+        void Expand();
+        void Collapse();
+        UiaExpandCollapseState ExpandCollapseState { get; }
+    }
+
+    [ComVisible(true)]
+    [Guid("2ACAD808-B2D4-452D-A407-91FF1AD167B2")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface ISelectionItemProvider
+    {
+        void Select();
+        void AddToSelection();
+        void RemoveFromSelection();
+        bool IsSelected { get; }
+        IRawElementProviderSimple SelectionContainer { get; }
+    }
+
+    internal static class UiaIds
+    {
+        public const int UiaRootObjectId = -25;
+        public const int UiaAppendRuntimeId = 3;
+
+        public const int StructureChangedEventId = 20002;
+        public const int AutomationFocusChangedEventId = 20005;
+
+        public const int InvokePatternId = 10000;
+        public const int ValuePatternId = 10002;
+        public const int ExpandCollapsePatternId = 10005;
+        public const int SelectionItemPatternId = 10010;
+        public const int TogglePatternId = 10015;
+
+        public const int RuntimeIdPropertyId = 30000;
+        public const int BoundingRectanglePropertyId = 30001;
+        public const int ProcessIdPropertyId = 30002;
+        public const int ControlTypePropertyId = 30003;
+        public const int LocalizedControlTypePropertyId = 30004;
+        public const int NamePropertyId = 30005;
+        public const int HasKeyboardFocusPropertyId = 30008;
+        public const int IsKeyboardFocusablePropertyId = 30009;
+        public const int IsEnabledPropertyId = 30010;
+        public const int AutomationIdPropertyId = 30011;
+        public const int ClassNamePropertyId = 30012;
+        public const int HelpTextPropertyId = 30013;
+        public const int IsControlElementPropertyId = 30016;
+        public const int IsContentElementPropertyId = 30017;
+        public const int IsPasswordPropertyId = 30019;
+        public const int NativeWindowHandlePropertyId = 30020;
+        public const int IsOffscreenPropertyId = 30022;
+        public const int FrameworkIdPropertyId = 30024;
+        public const int IsRequiredForFormPropertyId = 30025;
+        public const int ValueValuePropertyId = 30045;
+        public const int ValueIsReadOnlyPropertyId = 30046;
+        public const int ExpandCollapseExpandCollapseStatePropertyId = 30070;
+        public const int SelectionItemIsSelectedPropertyId = 30079;
+        public const int ToggleToggleStatePropertyId = 30086;
+
+        public const int ButtonControlTypeId = 50000;
+        public const int CalendarControlTypeId = 50001;
+        public const int CheckBoxControlTypeId = 50002;
+        public const int ComboBoxControlTypeId = 50003;
+        public const int EditControlTypeId = 50004;
+        public const int HyperlinkControlTypeId = 50005;
+        public const int ImageControlTypeId = 50006;
+        public const int ListItemControlTypeId = 50007;
+        public const int ListControlTypeId = 50008;
+        public const int MenuControlTypeId = 50009;
+        public const int MenuItemControlTypeId = 50011;
+        public const int ProgressBarControlTypeId = 50012;
+        public const int RadioButtonControlTypeId = 50013;
+        public const int ScrollBarControlTypeId = 50014;
+        public const int SliderControlTypeId = 50015;
+        public const int StatusBarControlTypeId = 50017;
+        public const int TabControlTypeId = 50018;
+        public const int TabItemControlTypeId = 50019;
+        public const int TextControlTypeId = 50020;
+        public const int ToolTipControlTypeId = 50022;
+        public const int CustomControlTypeId = 50025;
+        public const int GroupControlTypeId = 50026;
+        public const int WindowControlTypeId = 50032;
+        public const int PaneControlTypeId = 50033;
+        public const int SeparatorControlTypeId = 50038;
+    }
+}

--- a/XcyUI.GLFW/manager/KeyValueManager.cs
+++ b/XcyUI.GLFW/manager/KeyValueManager.cs
@@ -16,6 +16,15 @@ namespace XcyUI.GLFW.manager
                 case Keys.End:
                     value = XKeyValue.End;
                     break;
+                case Keys.Space:
+                    value = XKeyValue.Space;
+                    break;
+                case Keys.Escape:
+                    value = XKeyValue.Escape;
+                    break;
+                case Keys.Tab:
+                    value = XKeyValue.Tab;
+                    break;
                 case Keys.Left:
                     value = XKeyValue.Left;
                     break;

--- a/XcyUI.GLFW/window/BaseWindow.cs
+++ b/XcyUI.GLFW/window/BaseWindow.cs
@@ -67,6 +67,7 @@ namespace XcyUI.GLFW.window
             OnLoad();
             RunAction?.Invoke();
             Render();
+            OnWindowReady();
             LoadIcon?.Invoke();
             LoadAction?.Invoke();
             glfw.ShowWindow(window);
@@ -216,6 +217,11 @@ namespace XcyUI.GLFW.window
         public unsafe virtual void OnLoad()
         {
             
+        }
+
+        protected virtual void OnWindowReady()
+        {
+
         }
 
         protected virtual void InitPlatforms()

--- a/XcyUI.GLFW/window/XWindow.cs
+++ b/XcyUI.GLFW/window/XWindow.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using XcyUI.events;
 using XcyUI.expansions;
+using XcyUI.GLFW.accessibility;
 using XcyUI.GLFW.curor;
 using XcyUI.GLFW.manager;
 using XcyUI.GLFW.windowStyle;
@@ -18,6 +19,7 @@ namespace XcyUI.GLFW.window
         private const double doubleClickInterval = 300;
         private double lastClickTime;
         private MouseButton lastClickButton;
+        private WindowsUiaBridge accessibilityProvider;
 
         protected unsafe override void OnWindowCreate()
         {
@@ -72,6 +74,41 @@ namespace XcyUI.GLFW.window
             {
                 XThemeManager.Theme.DefaultFontName = "PingFang SC";
             }
+        }
+
+        protected override void OnWindowReady()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                InstallAccessibilityProvider();
+            }
+        }
+
+        private unsafe void InstallAccessibilityProvider()
+        {
+            var hwnd = WindowStyleImp.GetWin32Window(window);
+            if (hwnd == System.IntPtr.Zero)
+            {
+                return;
+            }
+
+            accessibilityProvider?.Dispose();
+            accessibilityProvider = new WindowsUiaBridge(
+                hwnd,
+                () => RenderBackend?.GetAccessibilityTree(),
+                action => ExecuteOnMainThread(action));
+            AddCloseAction(() =>
+            {
+                accessibilityProvider?.Dispose();
+                accessibilityProvider = null;
+            });
+        }
+
+        public override void OnDestory()
+        {
+            accessibilityProvider?.Dispose();
+            accessibilityProvider = null;
+            base.OnDestory();
         }
 
         protected override unsafe void OnCursorEnterCallback(bool entered)
@@ -179,7 +216,7 @@ namespace XcyUI.GLFW.window
 
         protected override void OnKeyCallback(Keys key, int scanCode, InputAction action, KeyModifiers mods)
         {
-            if (XEvent.FocusView != null && action == InputAction.Press)
+            if (action == InputAction.Press)
             {
                 var actionEvent = new XEventInfo
                 {
@@ -187,7 +224,7 @@ namespace XcyUI.GLFW.window
                     EventType = XEventType.KeyPress,
                     KeyModify = (KeyModify)mods
                 };
-                DispatchEvent(XEvent.FocusView, actionEvent);
+                DispatchEvent(actionEvent);
             }
         }
 

--- a/XcyUI.SkiaSharp/SkiaRenderBackend.cs
+++ b/XcyUI.SkiaSharp/SkiaRenderBackend.cs
@@ -1,6 +1,6 @@
-﻿using SkiaSharp;
+using SkiaSharp;
 using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using XcyUI.animation;
 using XcyUI.events;
 using XcyUI.models;
@@ -19,7 +19,7 @@ namespace XcyUI.SkiaSharp
         public XNavigationPage Navigation { get; private set; }
         public SKColor BackgoundColor { get; set; }
         private bool isDrak = false;
-        //private SKFont skFont;
+
         public SkiaRenderBackend()
         {
             SkiaDraw = new SkiaDraw();
@@ -27,32 +27,23 @@ namespace XcyUI.SkiaSharp
             RenderImp.SetDraw(SkiaDraw);
             isDrak = XTheme.DarkModeState.Value;
             BackgoundColor = XThemeManager.Theme.Colors.Background.ToSKColor();
-            //skFont = new SKFont()
-            //{
-            //    Subpixel = true,
-            //    LinearMetrics = true,
-            //    Hinting = SKFontHinting.Full,
-            //    Edging = SKFontEdging.SubpixelAntialias,
-            //    Size = 40,
-            //    Typeface = SKTypeface.FromFamilyName("Microsoft YaHei", new SKFontStyle(500, 6, SKFontStyleSlant.Upright))
-            //};
         }
+
         public void ResetSurface(int width, int height, object paramsData)
         {
             grContext?.Flush();
             grContext?.PurgeUnusedResources(100);
-            //grContext?.ResetContext();
             surface?.Dispose();
             CreateSurface(width, height);
         }
-        //GRGlGetProcedureAddressDelegate get;
+
         public void CreateSurface(int width, int height, object paramsData)
         {
             Delegate del = (Delegate)paramsData;
             GRGlGetProcedureAddressDelegate get = (GRGlGetProcedureAddressDelegate)Delegate.CreateDelegate(
                 typeof(GRGlGetProcedureAddressDelegate),
-                del.Target,    // 方法所属对象
-                del.Method     // 方法信息
+                del.Target,
+                del.Method
             );
             var gl = GRGlInterface.Create(get);
             grContext = GRContext.CreateGl(gl);
@@ -128,6 +119,16 @@ namespace XcyUI.SkiaSharp
         public void Open(XPage page)
         {
             Navigation?.Open(page);
+        }
+
+        public XAccessibilityNode GetAccessibilityTree()
+        {
+            return Navigation?.GetAccessibilityTree();
+        }
+
+        public List<XAccessibilityIssue> AuditAccessibility()
+        {
+            return Navigation?.AuditAccessibility() ?? new List<XAccessibilityIssue>();
         }
 
         public void Dispose()

--- a/XcyUI/events/XEvent.cs
+++ b/XcyUI/events/XEvent.cs
@@ -18,6 +18,7 @@ namespace XcyUI.events
         internal static List<XView> PreHoverViews = new List<XView>();
         //获取焦点的view
         public static XView FocusView { get; private set; }
+        public static event Action<XView> AccessibilityFocusChanged;
 
         public static int X { get; private set; }
         public static int Y { get; private set; }
@@ -27,13 +28,23 @@ namespace XcyUI.events
         }
         public static void ClearFocusView()
         {
+            var oldFocusView = FocusView;
             FocusView = null;
+            if (oldFocusView != null)
+            {
+                AccessibilityFocusChanged?.Invoke(null);
+            }
         }
         public static void Clear()
         {
+            var oldFocusView = FocusView;
             TargetView = null;
             HoverView = null;
             FocusView = null;
+            if (oldFocusView != null)
+            {
+                AccessibilityFocusChanged?.Invoke(null);
+            }
         }
         private static LinkedList<XView> views = new LinkedList<XView>();
 
@@ -79,6 +90,11 @@ namespace XcyUI.events
 
         private static void DoDispatch(XView root, XEventInfo info)
         {
+            if (IsInputEvent(info.EventType) && HandleKeyboard(root, info))
+            {
+                return;
+            }
+
             if (TargetView != null)
             {
                 HandleEvent(TargetView, info);
@@ -91,9 +107,7 @@ namespace XcyUI.events
             }
             if (info.EventType == XEventType.Down && FocusView!=null && !FocusView.RenderRect.Contain(info.Point))
             {
-                DoEvent(FocusView, info.Copy(XEventType.LossFocused), true);
-                RenderImp.Invalidate(FocusView);
-                FocusView = null;
+                SetFocus(null, info);
             }
             // 查找可以响应事件的view
             views.Clear();
@@ -185,19 +199,132 @@ namespace XcyUI.events
                     break;
                 case XEventType.Down:
                     TargetView = view;
-                    if (view.EventParams.Focusable && view != FocusView)
-                    {
-                        DoEvent(view, info.Copy(XEventType.Focused),true);
-                        if (FocusView != null)
-                        {
-                            DoEvent(FocusView, info.Copy(XEventType.LossFocused), true);
-                            FocusView.DrawCache.IsRefreshCache = true;
-                        }
-                        FocusView = view;
-                    }
+                    SetFocus(view, info);
                     break;
             }
             
+        }
+
+        public static bool SetFocus(XView view)
+        {
+            return SetFocus(view, null);
+        }
+
+        public static bool SetFocus(XView view, XEventInfo sourceInfo)
+        {
+            if (view == FocusView)
+            {
+                return true;
+            }
+
+            if (view != null && !CanReceiveFocus(view))
+            {
+                return false;
+            }
+
+            var oldFocusView = FocusView;
+            if (oldFocusView != null)
+            {
+                var lossInfo = sourceInfo?.Copy(XEventType.LossFocused) ?? new XEventInfo() { EventType = XEventType.LossFocused };
+                DoEvent(oldFocusView, lossInfo, true);
+                oldFocusView.DrawCache.IsRefreshCache = true;
+            }
+
+            FocusView = view;
+            if (FocusView != null)
+            {
+                var focusInfo = sourceInfo?.Copy(XEventType.Focused) ?? new XEventInfo() { EventType = XEventType.Focused };
+                focusInfo.X = FocusView.RenderRect.Center.X;
+                focusInfo.Y = FocusView.RenderRect.Center.Y;
+                DoEvent(FocusView, focusInfo, true);
+                FocusView.DrawCache.IsRefreshCache = true;
+                RenderImp.Invalidate(FocusView);
+            }
+
+            if (oldFocusView != null)
+            {
+                RenderImp.Invalidate(oldFocusView);
+            }
+
+            AccessibilityFocusChanged?.Invoke(FocusView);
+
+            return true;
+        }
+
+        public static bool MoveFocus(XView root, bool forward = true)
+        {
+            var focusableViews = XAccessibility.GetFocusableViews(root);
+            if (focusableViews.Count == 0)
+            {
+                return false;
+            }
+
+            var currentIndex = FocusView == null ? -1 : focusableViews.IndexOf(FocusView);
+            int nextIndex;
+            if (currentIndex < 0)
+            {
+                nextIndex = forward ? 0 : focusableViews.Count - 1;
+            }
+            else
+            {
+                nextIndex = forward ? currentIndex + 1 : currentIndex - 1;
+                if (nextIndex >= focusableViews.Count)
+                {
+                    nextIndex = 0;
+                }
+                else if (nextIndex < 0)
+                {
+                    nextIndex = focusableViews.Count - 1;
+                }
+            }
+
+            return SetFocus(focusableViews[nextIndex]);
+        }
+
+        public static bool Activate(XView view)
+        {
+            return Activate(view, null);
+        }
+
+        public static bool Activate(XView view, XEventInfo sourceInfo)
+        {
+            if (!XAccessibility.IsKeyboardActivatable(view))
+            {
+                return false;
+            }
+
+            var info = sourceInfo?.Copy(XEventType.Click) ?? new XEventInfo() { EventType = XEventType.Click };
+            info.X = view.RenderRect.Center.X;
+            info.Y = view.RenderRect.Center.Y;
+            info.IsLeft = true;
+            DoEvent(view, info, true);
+            RenderImp.Invalidate(view);
+            return true;
+        }
+
+        private static bool HandleKeyboard(XView root, XEventInfo info)
+        {
+            if (info.KeyValue == XKeyValue.Tab)
+            {
+                var isShift = (info.KeyModify & KeyModify.Shift) == KeyModify.Shift;
+                return MoveFocus(root, !isShift);
+            }
+
+            if ((info.KeyValue == XKeyValue.Enter || info.KeyValue == XKeyValue.Space)
+                && Activate(FocusView, info))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool CanReceiveFocus(XView view)
+        {
+            return view != null
+                && view.EventParams.Focusable
+                && XAccessibility.IsEnabled(view)
+                && XAccessibility.IsVisibleToAccessibility(view);
         }
 
         private static void PopEvent(XView view, XEventInfo info)
@@ -232,6 +359,10 @@ namespace XcyUI.events
                 info.EventType = isFocus ? XEventType.Focused : XEventType.LossFocused;
                 DoEvent(FocusView, info, true);
                 FocusView.DrawCache.IsRefreshCache = true;
+                if (isFocus)
+                {
+                    AccessibilityFocusChanged?.Invoke(FocusView);
+                }
             }
         }
 

--- a/XcyUI/extensions/XViewExtensions.cs
+++ b/XcyUI/extensions/XViewExtensions.cs
@@ -281,6 +281,7 @@ namespace XcyUI.expansions
         {
             view.LayoutParams.Reset();
             view.Style.Reset();
+            view.Accessibility.Reset();
             view.EventParams.Event(XEventType.Dispose)?.Invoke(view, null);
             view.EventParams.Clear();
             if(view is XGroup)

--- a/XcyUI/models/IRenderBackend.cs
+++ b/XcyUI/models/IRenderBackend.cs
@@ -1,4 +1,5 @@
-﻿using XcyUI.navigation;
+using System.Collections.Generic;
+using XcyUI.navigation;
 using XcyUI.views;
 
 namespace XcyUI.models
@@ -13,6 +14,8 @@ namespace XcyUI.models
         void Layout(int width, int height);
         void Focus(bool foucus);
         void Open(XPage page);
+        XAccessibilityNode GetAccessibilityTree();
+        List<XAccessibilityIssue> AuditAccessibility();
         void Dispose();
     }
 }

--- a/XcyUI/models/XAccessibilityModels.cs
+++ b/XcyUI/models/XAccessibilityModels.cs
@@ -1,0 +1,623 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using XcyUI.events;
+using XcyUI.expansions;
+using XcyUI.views;
+
+namespace XcyUI.models
+{
+    public enum XAccessibilityRole
+    {
+        None,
+        Application,
+        Window,
+        Group,
+        Text,
+        Heading,
+        Button,
+        Link,
+        Image,
+        TextBox,
+        TextArea,
+        CheckBox,
+        RadioButton,
+        Switch,
+        ComboBox,
+        ListBox,
+        ListItem,
+        Menu,
+        MenuItem,
+        Dialog,
+        Tooltip,
+        ProgressBar,
+        Slider,
+        ScrollBar,
+        Separator,
+        Tab,
+        TabPanel,
+        DatePicker,
+        Status,
+        Alert
+    }
+
+    public enum XAccessibilityLiveRegion
+    {
+        Off,
+        Polite,
+        Assertive
+    }
+
+    public enum XAccessibilityIssueSeverity
+    {
+        Info,
+        Warning,
+        Error
+    }
+
+    public class XAccessibilityParams
+    {
+        public XAccessibilityRole Role { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Value { get; set; }
+        public string Hint { get; set; }
+        public XView LabelledBy { get; set; }
+        public XView DescribedBy { get; set; }
+        public bool IsHidden { get; set; }
+        public bool MergeDescendants { get; set; }
+        public bool? IsEnabled { get; set; }
+        public bool? IsChecked { get; set; }
+        public bool? IsSelected { get; set; }
+        public bool? IsExpanded { get; set; }
+        public bool? IsPressed { get; set; }
+        public bool? IsReadOnly { get; set; }
+        public bool? IsRequired { get; set; }
+        public bool? IsInvalid { get; set; }
+        public bool? IsMultiline { get; set; }
+        public bool? IsPassword { get; set; }
+        public int HeadingLevel { get; set; }
+        public int PositionInSet { get; set; }
+        public int SetSize { get; set; }
+        public int TabIndex { get; set; }
+        public XAccessibilityLiveRegion LiveRegion { get; set; }
+
+        public XAccessibilityParams()
+        {
+            Reset();
+        }
+
+        public void Reset()
+        {
+            Role = XAccessibilityRole.None;
+            Name = null;
+            Description = null;
+            Value = null;
+            Hint = null;
+            LabelledBy = null;
+            DescribedBy = null;
+            IsHidden = false;
+            MergeDescendants = false;
+            IsEnabled = null;
+            IsChecked = null;
+            IsSelected = null;
+            IsExpanded = null;
+            IsPressed = null;
+            IsReadOnly = null;
+            IsRequired = null;
+            IsInvalid = null;
+            IsMultiline = null;
+            IsPassword = null;
+            HeadingLevel = 0;
+            PositionInSet = 0;
+            SetSize = 0;
+            TabIndex = 0;
+            LiveRegion = XAccessibilityLiveRegion.Off;
+        }
+    }
+
+    public class XAccessibilityNode
+    {
+        public XView View { get; set; }
+        public int Key { get; set; }
+        public XAccessibilityRole Role { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Value { get; set; }
+        public string Hint { get; set; }
+        public XRect Bounds { get; set; }
+        public bool Enabled { get; set; }
+        public bool Focusable { get; set; }
+        public bool Focused { get; set; }
+        public bool Hidden { get; set; }
+        public bool? Checked { get; set; }
+        public bool? Selected { get; set; }
+        public bool? Expanded { get; set; }
+        public bool? Pressed { get; set; }
+        public bool? ReadOnly { get; set; }
+        public bool? Required { get; set; }
+        public bool? Invalid { get; set; }
+        public bool? Multiline { get; set; }
+        public bool? Password { get; set; }
+        public int HeadingLevel { get; set; }
+        public int PositionInSet { get; set; }
+        public int SetSize { get; set; }
+        public XAccessibilityLiveRegion LiveRegion { get; set; }
+        public List<XAccessibilityNode> Children { get; private set; }
+
+        public XAccessibilityNode()
+        {
+            Children = new List<XAccessibilityNode>();
+        }
+    }
+
+    public class XAccessibilityIssue
+    {
+        public XView View { get; set; }
+        public XAccessibilityIssueSeverity Severity { get; set; }
+        public string Message { get; set; }
+    }
+
+    public static class XAccessibility
+    {
+        public static event Action<XView> StructureChanged;
+
+        public static void NotifyStructureChanged(XView container)
+        {
+            StructureChanged?.Invoke(container);
+        }
+
+        public static XAccessibilityNode BuildTree(XView root)
+        {
+            if (root == null)
+            {
+                return null;
+            }
+
+            var nodes = BuildNodes(root, true);
+            if (nodes.Count == 0)
+            {
+                return null;
+            }
+
+            if (nodes.Count == 1)
+            {
+                return nodes[0];
+            }
+
+            var node = CreateNode(root, nodes);
+            node.Role = XAccessibilityRole.Group;
+            return node;
+        }
+
+        public static List<XView> GetFocusableViews(XView root)
+        {
+            var views = new List<XView>();
+            AddFocusableViews(root, views);
+            var positiveTabIndex = views.Where(n => n.Accessibility.TabIndex > 0)
+                .OrderBy(n => n.Accessibility.TabIndex)
+                .ToList();
+            positiveTabIndex.AddRange(views.Where(n => n.Accessibility.TabIndex == 0));
+            return positiveTabIndex;
+        }
+
+        public static bool IsKeyboardFocusable(XView view)
+        {
+            if (view == null)
+            {
+                return false;
+            }
+
+            return IsVisibleToAccessibility(view)
+                && IsEnabled(view)
+                && view.EventParams.Focusable
+                && view.Accessibility.TabIndex >= 0;
+        }
+
+        public static bool IsKeyboardActivatable(XView view)
+        {
+            if (view == null || !IsEnabled(view) || !IsVisibleToAccessibility(view))
+            {
+                return false;
+            }
+
+            var role = GetRole(view);
+            if (role == XAccessibilityRole.TextBox || role == XAccessibilityRole.TextArea)
+            {
+                return false;
+            }
+
+            return view.EventParams.Contains(XEventType.Click);
+        }
+
+        public static bool IsEnabled(XView view)
+        {
+            if (view == null)
+            {
+                return false;
+            }
+
+            return view.Accessibility.IsEnabled ?? view.EventParams.Enable;
+        }
+
+        public static bool IsVisibleToAccessibility(XView view)
+        {
+            return view != null
+                && !view.Accessibility.IsHidden
+                && view.LayoutParams.Visible == XVisibleType.Visible;
+        }
+
+        public static bool IsInteractive(XView view)
+        {
+            if (view == null)
+            {
+                return false;
+            }
+
+            var role = GetRole(view);
+            return view.EventParams.Focusable
+                || view.EventParams.Contains(XEventType.Click)
+                || role == XAccessibilityRole.Button
+                || role == XAccessibilityRole.Link
+                || role == XAccessibilityRole.CheckBox
+                || role == XAccessibilityRole.RadioButton
+                || role == XAccessibilityRole.Switch
+                || role == XAccessibilityRole.ComboBox
+                || role == XAccessibilityRole.TextBox
+                || role == XAccessibilityRole.TextArea
+                || role == XAccessibilityRole.DatePicker
+                || role == XAccessibilityRole.Slider;
+        }
+
+        public static XAccessibilityRole GetRole(XView view)
+        {
+            if (view == null)
+            {
+                return XAccessibilityRole.None;
+            }
+
+            if (view.Accessibility.Role != XAccessibilityRole.None)
+            {
+                return view.Accessibility.Role;
+            }
+
+            var input = view as XInput;
+            if (input != null)
+            {
+                return input.Lines == 1 ? XAccessibilityRole.TextBox : XAccessibilityRole.TextArea;
+            }
+
+            if (view.EventParams.Contains(XEventType.Click))
+            {
+                return XAccessibilityRole.Button;
+            }
+
+            if (view is XText)
+            {
+                return XAccessibilityRole.Text;
+            }
+
+            if (view is XGroup)
+            {
+                return XAccessibilityRole.Group;
+            }
+
+            return XAccessibilityRole.None;
+        }
+
+        public static string GetAccessibleName(XView view)
+        {
+            if (view == null)
+            {
+                return "";
+            }
+
+            var accessibility = view.Accessibility;
+            if (!string.IsNullOrWhiteSpace(accessibility.Name))
+            {
+                return accessibility.Name;
+            }
+
+            if (accessibility.LabelledBy != null)
+            {
+                return GetText(accessibility.LabelledBy);
+            }
+
+            var input = view as XInput;
+            if (input != null && !string.IsNullOrWhiteSpace(input.Hint))
+            {
+                return input.Hint;
+            }
+
+            var text = view as XText;
+            if (text != null && !string.IsNullOrWhiteSpace(text.Text))
+            {
+                return text.Text;
+            }
+
+            if (accessibility.MergeDescendants || IsInteractive(view))
+            {
+                return GetDescendantText(view);
+            }
+
+            return "";
+        }
+
+        public static string GetAccessibleDescription(XView view)
+        {
+            if (view == null)
+            {
+                return "";
+            }
+
+            if (!string.IsNullOrWhiteSpace(view.Accessibility.Description))
+            {
+                return view.Accessibility.Description;
+            }
+
+            if (view.Accessibility.DescribedBy != null)
+            {
+                return GetText(view.Accessibility.DescribedBy);
+            }
+
+            return "";
+        }
+
+        public static string GetAccessibleValue(XView view)
+        {
+            if (view == null)
+            {
+                return "";
+            }
+
+            if (!string.IsNullOrWhiteSpace(view.Accessibility.Value))
+            {
+                return view.Accessibility.Value;
+            }
+
+            var input = view as XInput;
+            if (input != null)
+            {
+                return input.Text;
+            }
+
+            return "";
+        }
+
+        public static List<XAccessibilityIssue> Audit(XView root)
+        {
+            var issues = new List<XAccessibilityIssue>();
+            Audit(root, issues);
+            return issues;
+        }
+
+        private static void Audit(XView view, List<XAccessibilityIssue> issues)
+        {
+            if (view == null)
+            {
+                return;
+            }
+
+            if (IsVisibleToAccessibility(view))
+            {
+                var role = GetRole(view);
+                var isInteractive = IsInteractive(view);
+                var name = GetAccessibleName(view);
+                if (isInteractive && string.IsNullOrWhiteSpace(name))
+                {
+                    issues.Add(new XAccessibilityIssue()
+                    {
+                        View = view,
+                        Severity = XAccessibilityIssueSeverity.Warning,
+                        Message = "Interactive views must have an accessible name."
+                    });
+                }
+
+                if (view.EventParams.Focusable && !IsEnabled(view))
+                {
+                    issues.Add(new XAccessibilityIssue()
+                    {
+                        View = view,
+                        Severity = XAccessibilityIssueSeverity.Warning,
+                        Message = "Disabled views should not remain keyboard focusable."
+                    });
+                }
+
+                if (role == XAccessibilityRole.Heading && view.Accessibility.HeadingLevel <= 0)
+                {
+                    issues.Add(new XAccessibilityIssue()
+                    {
+                        View = view,
+                        Severity = XAccessibilityIssueSeverity.Info,
+                        Message = "Heading views should include a heading level."
+                    });
+                }
+            }
+
+            for (var i = 0; i < view.ChildCount(); i++)
+            {
+                Audit(view.ChildElemnt(i), issues);
+            }
+        }
+
+        private static List<XAccessibilityNode> BuildNodes(XView view, bool forceInclude)
+        {
+            var result = new List<XAccessibilityNode>();
+            if (!IsVisibleToAccessibility(view))
+            {
+                return result;
+            }
+
+            var children = new List<XAccessibilityNode>();
+            if (!view.Accessibility.MergeDescendants)
+            {
+                for (var i = 0; i < view.ChildCount(); i++)
+                {
+                    children.AddRange(BuildNodes(view.ChildElemnt(i), false));
+                }
+            }
+
+            if (forceInclude || ShouldInclude(view))
+            {
+                result.Add(CreateNode(view, children));
+            }
+            else
+            {
+                result.AddRange(children);
+            }
+
+            return result;
+        }
+
+        private static XAccessibilityNode CreateNode(XView view, List<XAccessibilityNode> children)
+        {
+            var accessibility = view.Accessibility;
+            var node = new XAccessibilityNode()
+            {
+                View = view,
+                Key = view.Key,
+                Role = GetRole(view),
+                Name = GetAccessibleName(view),
+                Description = GetAccessibleDescription(view),
+                Value = GetAccessibleValue(view),
+                Hint = accessibility.Hint,
+                Bounds = view.RenderRect,
+                Enabled = IsEnabled(view),
+                Focusable = IsKeyboardFocusable(view),
+                Focused = view == XEvent.FocusView,
+                Hidden = accessibility.IsHidden,
+                Checked = accessibility.IsChecked,
+                Selected = accessibility.IsSelected,
+                Expanded = accessibility.IsExpanded,
+                Pressed = accessibility.IsPressed,
+                ReadOnly = accessibility.IsReadOnly,
+                Required = accessibility.IsRequired,
+                Invalid = accessibility.IsInvalid,
+                Multiline = accessibility.IsMultiline,
+                Password = accessibility.IsPassword,
+                HeadingLevel = accessibility.HeadingLevel,
+                PositionInSet = accessibility.PositionInSet,
+                SetSize = accessibility.SetSize,
+                LiveRegion = accessibility.LiveRegion
+            };
+            node.Children.AddRange(children);
+            return node;
+        }
+
+        private static bool ShouldInclude(XView view)
+        {
+            var role = GetRole(view);
+            if (role == XAccessibilityRole.None)
+            {
+                return HasAccessibilityState(view) || IsInteractive(view);
+            }
+
+            if (role == XAccessibilityRole.Group && !HasAccessibilityState(view) && !IsInteractive(view))
+            {
+                return false;
+            }
+
+            if (view is XText && string.IsNullOrWhiteSpace(((XText)view).Text) && !HasAccessibilityState(view))
+            {
+                return false;
+            }
+
+            if (view is XIcon && string.IsNullOrWhiteSpace(view.Accessibility.Name) && !IsInteractive(view))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool HasAccessibilityState(XView view)
+        {
+            var accessibility = view.Accessibility;
+            return !string.IsNullOrWhiteSpace(accessibility.Name)
+                || !string.IsNullOrWhiteSpace(accessibility.Description)
+                || !string.IsNullOrWhiteSpace(accessibility.Value)
+                || !string.IsNullOrWhiteSpace(accessibility.Hint)
+                || accessibility.LabelledBy != null
+                || accessibility.DescribedBy != null
+                || accessibility.IsEnabled.HasValue
+                || accessibility.IsChecked.HasValue
+                || accessibility.IsSelected.HasValue
+                || accessibility.IsExpanded.HasValue
+                || accessibility.IsPressed.HasValue
+                || accessibility.IsReadOnly.HasValue
+                || accessibility.IsRequired.HasValue
+                || accessibility.IsInvalid.HasValue
+                || accessibility.IsMultiline.HasValue
+                || accessibility.IsPassword.HasValue
+                || accessibility.HeadingLevel > 0
+                || accessibility.PositionInSet > 0
+                || accessibility.SetSize > 0
+                || accessibility.LiveRegion != XAccessibilityLiveRegion.Off;
+        }
+
+        private static void AddFocusableViews(XView view, List<XView> views)
+        {
+            if (view == null || !IsVisibleToAccessibility(view))
+            {
+                return;
+            }
+
+            if (IsKeyboardFocusable(view))
+            {
+                views.Add(view);
+            }
+
+            for (var i = 0; i < view.ChildCount(); i++)
+            {
+                AddFocusableViews(view.ChildElemnt(i), views);
+            }
+        }
+
+        private static string GetText(XView view)
+        {
+            if (view == null || !IsVisibleToAccessibility(view))
+            {
+                return "";
+            }
+
+            var text = view as XText;
+            if (text != null)
+            {
+                return text.Text ?? "";
+            }
+
+            return GetDescendantText(view);
+        }
+
+        private static string GetDescendantText(XView view)
+        {
+            var parts = new List<string>();
+            AddDescendantText(view, parts);
+            return string.Join(" ", parts.Where(n => !string.IsNullOrWhiteSpace(n)).ToArray()).Trim();
+        }
+
+        private static void AddDescendantText(XView view, List<string> parts)
+        {
+            if (view == null || !IsVisibleToAccessibility(view))
+            {
+                return;
+            }
+
+            for (var i = 0; i < view.ChildCount(); i++)
+            {
+                var child = view.ChildElemnt(i);
+                var text = child as XText;
+                if (text != null)
+                {
+                    if (!string.IsNullOrWhiteSpace(text.Text))
+                    {
+                        parts.Add(text.Text);
+                    }
+                    continue;
+                }
+
+                AddDescendantText(child, parts);
+            }
+        }
+    }
+}

--- a/XcyUI/models/XEventModels.cs
+++ b/XcyUI/models/XEventModels.cs
@@ -49,19 +49,24 @@ namespace XcyUI.models
     }
     public class XKeyValue
     {
+        public const int Space = 32;
         public const int Home = 35;
         public const int End = 36;
         public const int Left = 37;
         public const int Up = 38;
         public const int Right = 39;
         public const int Down = 40;
+        public const int Escape = 256;
+        public const int Tab = 258;
         public const int Delete = 46;
         public const int Backspace = 259;
         public const int Enter = 257;
     }
 
+    [Flags]
     public enum KeyModify
     {
+        None = 0,
         Shift = 0x0001,
         Control = 0x0002,
         Alt = 0x0004,
@@ -91,7 +96,13 @@ namespace XcyUI.models
             action.Y = Y;
             action.IsLeft = IsLeft;
             action.EventType = eventType;
+            action.ClickKey = ClickKey;
             action.WheelSize = WheelSize;
+            action.IsVerticalWheel = IsVerticalWheel;
+            action.KeyChar = KeyChar;
+            action.KeyValue = KeyValue;
+            action.KeyModify = KeyModify;
+            action.Value = Value;
             return action;
         }
     }

--- a/XcyUI/navigation/XNavigationPage.cs
+++ b/XcyUI/navigation/XNavigationPage.cs
@@ -90,7 +90,24 @@ namespace XcyUI.navigation
             }
         }
 
-        public XGroup RouteView => ReversalPages().Pop().RootView as XGroup;
+        public XGroup RouteView
+        {
+            get
+            {
+                var pages = ReversalPages();
+                return pages != null && pages.Count > 0 ? pages.Pop().RootView as XGroup : null;
+            }
+        }
+
+        public XAccessibilityNode GetAccessibilityTree()
+        {
+            return RouteView == null ? null : XAccessibility.BuildTree(RouteView);
+        }
+
+        public List<XAccessibilityIssue> AuditAccessibility()
+        {
+            return RouteView == null ? new List<XAccessibilityIssue>() : XAccessibility.Audit(RouteView);
+        }
 
         public void Open(XPage page)
         {

--- a/XcyUI/views/XGroup.cs
+++ b/XcyUI/views/XGroup.cs
@@ -40,6 +40,7 @@ namespace XcyUI.views
         {
             view.Parent = this;
             Childs.Add(view);
+            XAccessibility.NotifyStructureChanged(this);
         }
 
         public void InsertView(int index,XView view)
@@ -48,6 +49,7 @@ namespace XcyUI.views
             {
                 view.Parent = this;
                 Childs.Insert(index, view);
+                XAccessibility.NotifyStructureChanged(this);
             }
         }
 
@@ -58,6 +60,7 @@ namespace XcyUI.views
             childs.Remove(view);
             Childs = childs;
             UpdateDrawViews();
+            XAccessibility.NotifyStructureChanged(this);
         }
 
         public override void Translation(int x, int y)

--- a/XcyUI/views/XScroller.cs
+++ b/XcyUI/views/XScroller.cs
@@ -19,7 +19,6 @@ namespace XcyUI.views
         public bool EnableScrolled { get; set; }
 
         private XPoint downPoint;
-        private int maxScrollerHeight;
         public XScroller()
         {
             Thickness = XThemeManager.Theme.Sizes.ScrollbarWidth.AsPx();
@@ -31,6 +30,10 @@ namespace XcyUI.views
         {
             HorizontalScollerBar = CreateScollerView(view);
             VerticalScollerBar = CreateScollerView(view);
+            HorizontalScollerBar.Accessibility.Role = XAccessibilityRole.ScrollBar;
+            HorizontalScollerBar.Accessibility.Name = "水平滚动条";
+            VerticalScollerBar.Accessibility.Role = XAccessibilityRole.ScrollBar;
+            VerticalScollerBar.Accessibility.Name = "垂直滚动条";
             HorizontalScollerBar.LayoutParams.Height = Thickness;
             HorizontalScollerBar.Height = Thickness;
             HorizontalScollerBar.LayoutParams.Margin = new XSpace(0, 0, 0, XThemeManager.Theme.Sizes.ScrollbarMargin.AsPx());

--- a/XcyUI/views/XView.cs
+++ b/XcyUI/views/XView.cs
@@ -12,6 +12,7 @@ namespace XcyUI.views
         public int Key { get; set; }
         public XLayoutParams LayoutParams { get; private set; }
         public XEventParams EventParams { get; private set; }
+        public XAccessibilityParams Accessibility { get; private set; }
         internal XDrawCache DrawCache { get; private set; }
         public XView Parent { get; set; }
 
@@ -45,6 +46,7 @@ namespace XcyUI.views
         {
             LayoutParams = new XLayoutParams();
             EventParams = new XEventParams();
+            Accessibility = new XAccessibilityParams();
             DrawCache = new XDrawCache();
             IsMeasured = true;
         }
@@ -145,6 +147,7 @@ namespace XcyUI.views
         {
 
         }
+
         public bool IsCache => DrawCache.EnableCache;
         public void EnableCache( bool enable, XCacheType type = XCacheType.Pictrue)
         {

--- a/XcyUI/widgets/XSpanBuilder.cs
+++ b/XcyUI/widgets/XSpanBuilder.cs
@@ -122,10 +122,13 @@ namespace XcyUI.widgets
         public XSpanBuilder Click(XFunction click)
         {
             var builder = new XViewBuilder(textView);
+            textView.EventParams.Focusable = true;
+            textView.Accessibility.Role = XAccessibilityRole.Link;
+            textView.Accessibility.Name = textView.Text.Substring(span.StartIndex, span.EndIndex - span.StartIndex + 1);
             builder
             .OnHover((b, info) =>
             {
-                var spanChars = textView.GetChars(span.StartIndex, span.EndIndex);
+                var spanChars = textView.GetChars(span.StartIndex, span.EndIndex) ?? new List<XChar>();
                 var isIn = spanChars.Count(n => n.RenderRect.Contain(info.Point)) > 0;
                 RenderImp.SetCursor(isIn ? XCursorType.Hand : XCursorType.Arrow);
             })
@@ -135,9 +138,10 @@ namespace XcyUI.widgets
             });
             textView.EventParams.EventOrCreate(XEventType.Click).AddFunction($"span_{span.StartIndex}_{span.EndIndex}", (b, info) =>
             {
-                var spanChars = textView.GetChars(span.StartIndex, span.EndIndex);
+                var spanChars = textView.GetChars(span.StartIndex, span.EndIndex) ?? new List<XChar>();
                 var isIn = spanChars.Count(n => n.RenderRect.Contain(info.Point)) > 0;
-                if (isIn)
+                var isKeyboard = info.KeyValue == XKeyValue.Enter || info.KeyValue == XKeyValue.Space;
+                if (isIn || isKeyboard)
                 {
                     click.Invoke();
                 }

--- a/XcyUI/widgets/XWidget.cs
+++ b/XcyUI/widgets/XWidget.cs
@@ -224,6 +224,8 @@ namespace XcyUI.widgets
                 .Clip()
                 .TextDefault()
                 .Content(text)
+                .AccessibilityRole(XAccessibilityRole.TextBox)
+                .AccessibilityMultiline(false)
                 .Lines(1)
                 .Width(XLayoutParams.Fill)
                 .CursorColor(XTheme.DarkModeState.Value?xTheme.Colors.White:xTheme.Colors.Black)

--- a/XcyUI/widgets/extensions/XAccessibilityBuilderExtensions.cs
+++ b/XcyUI/widgets/extensions/XAccessibilityBuilderExtensions.cs
@@ -1,0 +1,173 @@
+using XcyUI.events;
+using XcyUI.models;
+using XcyUI.views;
+
+namespace XcyUI.widgets.extensions
+{
+    public static class XAccessibilityBuilderExtensions
+    {
+        public static XViewBuilder Accessibility(this XViewBuilder builder, XAccessibilityRole role, string name = null)
+        {
+            return builder.AccessibilityRole(role).AccessibilityName(name);
+        }
+
+        public static XViewBuilder AccessibilityRole(this XViewBuilder builder, XAccessibilityRole role)
+        {
+            builder.View.Accessibility.Role = role;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityName(this XViewBuilder builder, string name)
+        {
+            if (name != null)
+            {
+                builder.View.Accessibility.Name = name;
+            }
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityDescription(this XViewBuilder builder, string description)
+        {
+            builder.View.Accessibility.Description = description;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityValue(this XViewBuilder builder, string value)
+        {
+            builder.View.Accessibility.Value = value;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityHint(this XViewBuilder builder, string hint)
+        {
+            builder.View.Accessibility.Hint = hint;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityLabelledBy(this XViewBuilder builder, XView labelView)
+        {
+            builder.View.Accessibility.LabelledBy = labelView;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityLabelledBy(this XViewBuilder builder, XViewBuilder labelBuilder)
+        {
+            return builder.AccessibilityLabelledBy(labelBuilder?.View);
+        }
+
+        public static XViewBuilder AccessibilityDescribedBy(this XViewBuilder builder, XView descriptionView)
+        {
+            builder.View.Accessibility.DescribedBy = descriptionView;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityDescribedBy(this XViewBuilder builder, XViewBuilder descriptionBuilder)
+        {
+            return builder.AccessibilityDescribedBy(descriptionBuilder?.View);
+        }
+
+        public static XViewBuilder AccessibilityHidden(this XViewBuilder builder, bool hidden = true)
+        {
+            builder.View.Accessibility.IsHidden = hidden;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityMergeDescendants(this XViewBuilder builder, bool merge = true)
+        {
+            builder.View.Accessibility.MergeDescendants = merge;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityEnabled(this XViewBuilder builder, bool? enabled)
+        {
+            builder.View.Accessibility.IsEnabled = enabled;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityChecked(this XViewBuilder builder, bool? isChecked)
+        {
+            builder.View.Accessibility.IsChecked = isChecked;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilitySelected(this XViewBuilder builder, bool? isSelected)
+        {
+            builder.View.Accessibility.IsSelected = isSelected;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityExpanded(this XViewBuilder builder, bool? isExpanded)
+        {
+            builder.View.Accessibility.IsExpanded = isExpanded;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityPressed(this XViewBuilder builder, bool? isPressed)
+        {
+            builder.View.Accessibility.IsPressed = isPressed;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityReadOnly(this XViewBuilder builder, bool? isReadOnly)
+        {
+            builder.View.Accessibility.IsReadOnly = isReadOnly;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityRequired(this XViewBuilder builder, bool? isRequired)
+        {
+            builder.View.Accessibility.IsRequired = isRequired;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityInvalid(this XViewBuilder builder, bool? isInvalid)
+        {
+            builder.View.Accessibility.IsInvalid = isInvalid;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityMultiline(this XViewBuilder builder, bool? isMultiline)
+        {
+            builder.View.Accessibility.IsMultiline = isMultiline;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityPassword(this XViewBuilder builder, bool? isPassword)
+        {
+            builder.View.Accessibility.IsPassword = isPassword;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityHeadingLevel(this XViewBuilder builder, int level)
+        {
+            builder.View.Accessibility.Role = XAccessibilityRole.Heading;
+            builder.View.Accessibility.HeadingLevel = level;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilitySetPosition(this XViewBuilder builder, int position, int setSize)
+        {
+            builder.View.Accessibility.PositionInSet = position;
+            builder.View.Accessibility.SetSize = setSize;
+            return builder;
+        }
+
+        public static XViewBuilder AccessibilityLiveRegion(this XViewBuilder builder, XAccessibilityLiveRegion liveRegion)
+        {
+            builder.View.Accessibility.LiveRegion = liveRegion;
+            return builder;
+        }
+
+        public static XViewBuilder TabIndex(this XViewBuilder builder, int tabIndex)
+        {
+            builder.View.Accessibility.TabIndex = tabIndex;
+            return builder;
+        }
+
+        public static XViewBuilder RequestFocus(this XViewBuilder builder)
+        {
+            XEvent.SetFocus(builder.View);
+            return builder;
+        }
+    }
+}

--- a/XcyUI/widgets/extensions/XEventBuilderExtensions.cs
+++ b/XcyUI/widgets/extensions/XEventBuilderExtensions.cs
@@ -51,6 +51,17 @@ namespace XcyUI.widgets.extensions
             return builder;
         }
 
+        private static XViewBuilder ClickableAccessibility(this XViewBuilder builder)
+        {
+            builder.View.EventParams.Focusable = true;
+            if (builder.View.Accessibility.Role == XAccessibilityRole.None)
+            {
+                builder.View.Accessibility.Role = XAccessibilityRole.Button;
+            }
+            builder.View.Accessibility.MergeDescendants = true;
+            return builder;
+        }
+
         public static XViewBuilder OnMove(this XViewBuilder builder, XFunction<XViewBuilder, XEventInfo> function, string key = "OnMove")
         {
             builder.View.AddEvent(XEventType.Move, key, (v, info) => function(builder, info));
@@ -93,6 +104,7 @@ namespace XcyUI.widgets.extensions
         public static XViewBuilder Click(this XViewBuilder builder, XFunction<XViewBuilder, XEventInfo> function, bool defaultEffect = true, string eventKey = "default_click")
         {
             builder.View.AddEvent(XEventType.Click,eventKey, (v, info) => function(builder, info));
+            builder.ClickableAccessibility();
             if (defaultEffect)
             {
                 builder.DefaultClickEffect();
@@ -107,6 +119,7 @@ namespace XcyUI.widgets.extensions
         public static XViewBuilder DoubleClick(this XViewBuilder builder, XFunction<XViewBuilder, XEventInfo> function, bool defaultEffect = true, string eventKey = "default_double_click")
         {
             builder.View.AddEvent(XEventType.DoubleClick, eventKey, (v, info) => function(builder, info));
+            builder.ClickableAccessibility();
             if (defaultEffect)
             {
                 builder.DefaultClickEffect();
@@ -132,6 +145,7 @@ namespace XcyUI.widgets.extensions
                 return builder;
             }
             builder.View.AddEvent(XEventType.Click, eventKey, function);
+            builder.ClickableAccessibility();
             if (defaultEffect)
             {
                 builder.DefaultClickEffect();

--- a/XcyUI/widgets/extensions/XGroupBuilderExtensions.cs
+++ b/XcyUI/widgets/extensions/XGroupBuilderExtensions.cs
@@ -102,6 +102,16 @@ namespace XcyUI.widgets.extensions
             if (builder.View is XGroup && builder.View.EventParams.Event(XEventType.Wheel) == null && builder.AsView<XGroup>()?.Scroller == null)
             {
                 var view = builder.AsView<XGroup>();
+                builder.Focusable(true);
+                if (builder.View.Accessibility.Role == XAccessibilityRole.None)
+                {
+                    builder.AccessibilityRole(XAccessibilityRole.Group);
+                }
+                if (string.IsNullOrEmpty(builder.View.Accessibility.Name))
+                {
+                    builder.AccessibilityName("滚动区域");
+                }
+                builder.KeyScroll(isVertical);
                 if (enableWheel)
                 {
                     var wheel = view.EventParams.EventOrCreate(XEventType.Wheel);
@@ -140,6 +150,42 @@ namespace XcyUI.widgets.extensions
                     });
                 }
             }
+            return builder;
+        }
+
+        private static XViewBuilder KeyScroll(this XViewBuilder builder, bool isVertical)
+        {
+            var view = builder.AsView<XGroup>();
+            if (view == null)
+            {
+                return builder;
+            }
+
+            builder.View.EventParams.EventOrCreate(XEventType.KeyPress).AddFunction("default_key_scroll", (v, info) =>
+            {
+                var size = 50.AsPx();
+                switch (info.KeyValue)
+                {
+                    case XKeyValue.Up:
+                        view.OnScolled(true, size);
+                        break;
+                    case XKeyValue.Down:
+                        view.OnScolled(true, -size);
+                        break;
+                    case XKeyValue.Left:
+                        view.OnScolled(false, size);
+                        break;
+                    case XKeyValue.Right:
+                        view.OnScolled(false, -size);
+                        break;
+                    case XKeyValue.Home:
+                        view.OnScolled(isVertical, int.MaxValue);
+                        break;
+                    case XKeyValue.End:
+                        view.OnScolled(isVertical, -int.MaxValue);
+                        break;
+                }
+            });
             return builder;
         }
 

--- a/XcyUI/widgets/extensions/XTextBuilderExtensions.cs
+++ b/XcyUI/widgets/extensions/XTextBuilderExtensions.cs
@@ -90,13 +90,25 @@ namespace XcyUI.widgets.extensions
 
         public static XViewBuilder ReadOnly(this XViewBuilder builder, bool readOnly = true)
         {
-            builder.AsView<XInput>()?.Also(n => n.ReadOnly = readOnly);
+            builder.AsView<XInput>()?.Also(n =>
+            {
+                n.ReadOnly = readOnly;
+                n.Accessibility.IsReadOnly = readOnly;
+            });
             return builder;
         }
 
         public static XViewBuilder Lines(this XViewBuilder builder, int lines)
         {
-            builder.AsView<XText>()?.Also(n => n.Lines = lines);
+            builder.AsView<XText>()?.Also(n =>
+            {
+                n.Lines = lines;
+                if (n is XInput)
+                {
+                    n.Accessibility.Role = lines == 1 ? XAccessibilityRole.TextBox : XAccessibilityRole.TextArea;
+                    n.Accessibility.IsMultiline = lines != 1;
+                }
+            });
             return builder;
         }
 
@@ -108,7 +120,11 @@ namespace XcyUI.widgets.extensions
 
         public static XViewBuilder Hint(this XViewBuilder builder, string text)
         {
-            builder.AsView<XInput>()?.Also(n => n.Hint = text);
+            builder.AsView<XInput>()?.Also(n =>
+            {
+                n.Hint = text;
+                n.Accessibility.Hint = text;
+            });
             return builder;
         }
 
@@ -123,6 +139,7 @@ namespace XcyUI.widgets.extensions
             builder.AsView<XInput>()?.Also(n =>
             {
                 n.SetPasswordChar(key);
+                n.Accessibility.IsPassword = key != null;
             });
             return builder;
         }


### PR DESCRIPTION
## 概要

为 XcyUI 增加 Windows UI Automation 无障碍支持，包括语义角色、可访问名称和值、键盘焦点导航及常用控件模式。

## 根因与修复

Windows 发布路径此前同时启用了 Native AOT 与裁剪，而 UIA Provider 需要通过托管 COM 公开接口。首个 UIA 请求可能导致 Provider 进程失效，且焦点和动态树变化没有发送 UIA 通知。

- 新增 Windows UIA Bridge、Fragment Provider 和无障碍树模型。
- 为内置控件补齐无障碍元数据和语义默认值。
- 上报焦点与子树变化事件，并将 UIA 调用调度回 UI 线程。
- 在 Provider 迁移到 source-generated ComWrappers 前，为 Windows 发布禁用 AOT 与裁剪。

## 验证

- `dotnet build XchyUIDemo.sln --no-restore -v:minimal`
- `dotnet publish Demo\Demo.csproj -c Release -r win-x64 --no-restore`
- Windows UIA smoke test：持续发现控件，并确认焦点和结构变更事件。
